### PR TITLE
add tp description for the triangular lattice

### DIFF
--- a/prog/hub_df.cpp
+++ b/prog/hub_df.cpp
@@ -234,7 +234,7 @@ alps::params cmdline_params(int argc, char* argv[])
     p.define<double>("t",  1.0,   "hopping on a lattice");
     #elif LATTICE_PARAMS == 2
     p.define<double>("t",  1.0,   "nearest neighbor hopping on a lattice");
-    p.define<double>("tp", 0.0,   "next-nearest neighbor hopping on a lattice");
+    p.define<double>("tp", 0.0,   "next-nearest neighbor hopping on a square lattice, anisotropic hopping along one direction on a triangular lattice (set 1.0 if you want an isotropic triangular lattice)");
     #else
     #error Undefined lattice
     #endif


### PR DESCRIPTION
I noticed that the triangular lattice uses `tp` to represent the anisotropic hopping but the description of this parameter is not clear enough in the code. The default value of `tp` is 0.0. Therefore, if we natively set `tp` equal the default value for the triangular lattice according to the description, the dispersion used in the code will be the dispersion for a square lattice instead of an isotropic triangular lattice. I didn't find a good way to modify the existed code to fix this small problem since all kinds of lattices use the same input format but at least we can make the description of the `tp` parameter more clear.